### PR TITLE
Remove unused dependencies crossbeam and parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ debug-logs = []
 
 [dependencies]
 breakpad-handler = { version = "0.1.0", path = "./breakpad-handler" }
-crossbeam = "0.8.0"
-parking_lot = "0.11"
 sentry-core = { version = "0.24", features = ["client"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
Thanks for your work on this crate.

I realized that some dependencies are no longer used, so they can be removed to clean up a bit the dependency tree and only depend on sentry and serde_json.