### PR TITLE
chore: update to sentry-core 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ debug-logs = []
 
 [dependencies]
 breakpad-handler = { version = "0.1.0", path = "./breakpad-handler" }
-sentry-core = { version = "0.25", features = ["client"] }
+sentry-core = { version = "0.26", features = ["client"] }
 serde_json = "1.0"
 
 [workspace]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Update to `sentry-core 0.26.0`.

This notably updates (transitively) to `uuid 1.0.0`, which is nice.

### Related Issues

*None*

### Other

Is it possible to get a release for this (I don't think it breaks any public API ?) once merged ?