### PR TITLE
cargo: Fix breakpad-sys/breakpad-handler homepages

### DIFF
--- a/breakpad-handler/Cargo.toml
+++ b/breakpad-handler/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Embark <opensource@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/breakpad-handler"
-homepage = "https://github.com/EmbarkStudios/sentry-contrib-rust/breakpad-handler"
+homepage = "https://github.com/EmbarkStudios/sentry-contrib-rust/tree/main/breakpad-handler"
 keywords = ["breakpad", "minidump", "crash"]
 readme = "README.md"
 

--- a/breakpad-sys/Cargo.toml
+++ b/breakpad-sys/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 # https://clearlydefined.io/definitions/git/github/google/breakpad/5bba75bfd6ec386b8e3af0b91332388a378135bf
 license = "BSD-3-Clause"
 documentation = "https://docs.rs/breakpad-sys"
-homepage = "https://github.com/EmbarkStudios/sentry-contrib-rust/breakpad-sys"
+homepage = "https://github.com/EmbarkStudios/sentry-contrib-rust/tree/main/breakpad-sys"
 keywords = ["breakpad", "minidump", "crash"]
 readme = "README.md"
 exclude = [


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The old links 404, we have to point to the tree view (and a `main` branch) explicitly.
