### PR TITLE
Fix a broken build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ debug-logs = []
 
 [dependencies]
 breakpad-handler = { version = "0.2.0", path = "./breakpad-handler" }
-sentry-core = { version = ">=0.29", features = ["client"] }
+sentry-core = { version = ">=0.31.7", features = ["client"] }
 serde_json = "1.0"
 
 [workspace]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -23,7 +23,7 @@ pub(crate) fn assemble_envelope(md: CrashMetadata, minidump_path: &Path) -> prot
             event_id: minidump_path
                 .file_stem()
                 .and_then(|fname| fname.to_str().and_then(|fs| fs.parse::<types::Uuid>().ok()))
-                .unwrap_or_else(types::Uuid::new_v4),
+                .unwrap_or_else(types::random_uuid),
             level: proto::Level::Fatal,
             timestamp,
             ..Default::default()


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The tip of tree currently breaks at:

```
    ...
       Compiling sentry-types v0.31.8
       Compiling sentry-core v0.31.8
       Compiling sentry-contrib-breakpad v0.8.0
    error[E0599]: no function or associated item named `new_v4` found for
      struct `Uuid` in the current scope --> src/shared.rs:26:46
       |
    26 | .unwrap_or_else(types::Uuid::new_v4),
       |                              ^^^^^^
       |                              |
       | function or associated item not found in `Uuid`
```

This is due to the fact that a breaking change was introduced at https://github.com/getsentry/sentry-rust/pull/614.

### Related Issues

List related issues here
