### PR TITLE
Add on demand minidump

### DIFF
--- a/breakpad-handler/src/lib.rs
+++ b/breakpad-handler/src/lib.rs
@@ -137,6 +137,14 @@ impl BreakpadHandler {
             Ok(Self { handler, on_crash })
         }
     }
+
+    pub fn generate_minidump(&self) -> bool {
+        #[allow(unsafe_code)]
+        // SAFETY: Calling into C code
+        unsafe {
+            breakpad_sys::generate_minidump(self.handler)
+        }
+    }
 }
 
 impl Drop for BreakpadHandler {

--- a/breakpad-sys/build.rs
+++ b/breakpad-sys/build.rs
@@ -59,6 +59,7 @@ fn main() {
                     "safe_readlink",
                 ],
             );
+            build.file("breakpad/src/common/linux/breakpad_getcontext.S");
 
             add_sources(&mut build, "breakpad/src/client/linux/log", &["log"]);
 

--- a/breakpad-sys/src/impl.cpp
+++ b/breakpad-sys/src/impl.cpp
@@ -149,4 +149,8 @@ extern "C" {
         delete handler->handler;
         delete handler;
     }
+
+    bool generate_minidump(ExcHandler* handler) {
+        return handler->handler->WriteMinidump();
+    }
 }

--- a/breakpad-sys/src/lib.rs
+++ b/breakpad-sys/src/lib.rs
@@ -35,4 +35,7 @@ extern "C" {
 
     /// Detaches and frees the exception handler
     pub fn detach_exception_handler(handler: *mut ExceptionHandler);
+
+    /// Generate a minidump immediately.
+    pub fn generate_minidump(handler: *mut ExceptionHandler) -> bool;
 }

--- a/src/breakpad_integration.rs
+++ b/src/breakpad_integration.rs
@@ -77,7 +77,7 @@ impl BreakpadIntegration {
                     crash_hub.capture_event(event);
 
                     if let Some(client) = crash_hub.client() {
-                        client.close(None);
+                        client.flush(None);
                     }
                 }
             }),

--- a/src/breakpad_integration.rs
+++ b/src/breakpad_integration.rs
@@ -92,6 +92,13 @@ impl BreakpadIntegration {
         })
     }
 
+    pub fn generate_minidump(&self) -> bool {
+        match self.crash_handler.as_ref() {
+            Some(handler) => handler.generate_minidump(),
+            None => false,
+        }
+    }
+
     /// Called during startup to send any minidumps + metadata that have been
     /// captured in previous sessions but (seem to) have not been sent yet
     fn upload_minidumps(crash_dir: &Path, hub: &sentry_core::Hub) {


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

It can be useful to generate a minidump of a program not only on crashes, but also on demand, when we can detect an invalid situation and want to generate a dump to be able to investigate it in details. Breakpad has this ability, so this MR simply exposes this through the Rust API.

### Description of Changes

A new `BreakpadHandler::generate_minidump` helper is added to generate a minidump on demand. The code is reworked and reworded to function with non fatal dumps.